### PR TITLE
Add standard metrics getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add `PrometheusMetrics::http_requests_total` and `PrometheusMetrics::http_requests_duration_seconds` methods to get a reference to the fairing's internal Prometheus metrics. 
-- Add `PrometheusMetrics::get_http_requests_duration_seconds` function.
 
 ## [0.10.0-rc.2] - 2022-05-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Add Liftoff Fairing with metrics initialization.
+
+- Add `PrometheusMetrics::get_http_requests_total` function.
+- Add `PrometheusMetrics::get_http_requests_duration_seconds` function.
 
 ## [0.10.0-rc.2] - 2022-05-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 
-- Add `PrometheusMetrics::get_http_requests_total` function.
+- Add `PrometheusMetrics::http_requests_total` and `PrometheusMetrics::http_requests_duration_seconds` methods to get a reference to the fairing's internal Prometheus metrics. 
 - Add `PrometheusMetrics::get_http_requests_duration_seconds` function.
 
 ## [0.10.0-rc.2] - 2022-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add Liftoff Fairing with metrics initialization.
 
 ## [0.10.0-rc.2] - 2022-05-14
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,12 +282,12 @@ impl PrometheusMetrics {
         &self.custom_registry
     }
 
-    /// Get `http_requests_total` metric.
+    /// Get the `http_requests_total` metric.
     pub fn http_requests_total(&self) -> &IntCounterVec {
         &self.http_requests_total
     }
 
-    /// Get `http_requests_duration_seconds` metric.
+    /// Get the `http_requests_duration_seconds` metric.
     pub fn http_requests_duration_seconds(&self) -> &HistogramVec {
         &self.http_requests_duration_seconds
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl PrometheusMetrics {
     }
 
     /// Get `http_requests_duration_seconds` metric.
-    pub fn get_http_requests_duration_seconds(&self) -> &HistogramVec {
+    pub fn http_requests_duration_seconds(&self) -> &HistogramVec {
         &self.http_requests_duration_seconds
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ impl PrometheusMetrics {
     }
 
     /// Get `http_requests_total` metric.
-    pub fn get_http_requests_total(&self) -> &IntCounterVec {
+    pub fn http_requests_total(&self) -> &IntCounterVec {
         &self.http_requests_total
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ use rocket::{
     fairing::{Fairing, Info, Kind},
     http::{ContentType, Method},
     route::{Handler, Outcome},
-    Data, Orbit, Request, Response, Rocket, Route,
+    Data, Request, Response, Route,
 };
 
 /// Re-export Prometheus so users can use it without having to explicitly
@@ -281,6 +281,16 @@ impl PrometheusMetrics {
     pub const fn registry(&self) -> &Registry {
         &self.custom_registry
     }
+
+    /// Get `http_requests_total` metric.
+    pub fn get_http_requests_total(&self) -> &IntCounterVec {
+        &self.http_requests_total
+    }
+
+    /// Get `http_requests_duration_seconds` metric.
+    pub fn get_http_requests_duration_seconds(&self) -> &HistogramVec {
+        &self.http_requests_duration_seconds
+    }
 }
 
 impl Default for PrometheusMetrics {
@@ -405,21 +415,7 @@ impl Fairing for PrometheusMetrics {
     fn info(&self) -> Info {
         Info {
             name: "Prometheus metric collection",
-            kind: Kind::Liftoff | Kind::Request | Kind::Response,
-        }
-    }
-
-    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
-        for route in rocket.routes() {
-            let uri = route.uri.as_str();
-            let method = route.method.as_str();
-            let status = StatusCode::from(200);
-
-            self.http_requests_total
-                .with_label_values(&[uri, method, status.as_str()]);
-
-            self.http_requests_duration_seconds
-                .with_label_values(&[uri, method, status.as_str()]);
+            kind: Kind::Request | Kind::Response,
         }
     }
 


### PR DESCRIPTION
Add `PrometheusMetrics::http_requests_total` and `PrometheusMetrics::http_requests_duration_seconds` methods to get a reference to the fairing's internal Prometheus metrics. For ability to custom initialize of these metrics, which required for correct handling of Counters resets.

Example:

```rust
    let base_statuses = vec!["200"];
    let api_statuses = vec!["200", "400", "401"];

    for route in rocket.routes() {
        let uri = route.uri.as_str();
        let method = route.method.as_str();
        let statuses = match uri {
            v if v.contains("api") => &api_statuses,
            _ => &base_statuses,
        };
        for status in statuses {
            prometheus
                .http_requests_total()
                .with_label_values(&[uri, method, status]);

            prometheus
                .http_requests_duration_seconds()
                .with_label_values(&[uri, method, status]);
        }
    }
```